### PR TITLE
OSX Support

### DIFF
--- a/src/ToolBox/SOS/lldbplugin/CMakeLists.txt
+++ b/src/ToolBox/SOS/lldbplugin/CMakeLists.txt
@@ -21,7 +21,6 @@ if((NOT ${LLDB_INCLUDE_DIR} STREQUAL "") AND (NOT ${LLDB_LIB_DIR} STREQUAL ""))
 
     include_directories(inc)
     include_directories("${LLDB_INCLUDE_DIR}")
-    link_directories("${LLDB_LIB_DIR}")
 
     set(SOURCES
         sosplugin.cpp
@@ -31,6 +30,15 @@ if((NOT ${LLDB_INCLUDE_DIR} STREQUAL "") AND (NOT ${LLDB_LIB_DIR} STREQUAL ""))
 
     add_library(sosplugin SHARED ${SOURCES})
     add_dependencies(sosplugin sos)
+
+    if(CLR_CMAKE_PLATFORM_LINUX)
+        link_directories("${LLDB_LIB_DIR}")
+    endif(CLR_CMAKE_PLATFORM_LINUX)
+
+    if(CLR_CMAKE_PLATFORM_DARWIN)
+        find_library(LLDB LLDB PATHS ${LLDB_LIB_DIR})
+        target_link_libraries(sosplugin ${LLDB})
+    endif(CLR_CMAKE_PLATFORM_DARWIN)
 
     # add the install targets
     install (TARGETS sosplugin DESTINATION .)

--- a/src/dlls/mscordac/CMakeLists.txt
+++ b/src/dlls/mscordac/CMakeLists.txt
@@ -30,14 +30,16 @@ if(WIN32)
     set(START_LIBRARY_GROUP)
     set(END_LIBRARY_GROUP)
 else(WIN32)
-    # This option is necessary to ensure that the overloaded delete operator defined inside
-    # of the utilcode will be used instead of the standard library delete operator.
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Xlinker -Bsymbolic-functions")
+    if(CLR_CMAKE_PLATFORM_LINUX)
+        # This option is necessary to ensure that the overloaded delete operator defined inside
+        # of the utilcode will be used instead of the standard library delete operator.
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Xlinker -Bsymbolic-functions")
 
-    # The following linked options can be inserted into the linker libraries list to 
-    # ensure proper resolving of circular references between a subset of the libraries.
-    set(START_LIBRARY_GROUP -Wl,--start-group)
-    set(END_LIBRARY_GROUP -Wl,--end-group)
+        # The following linked options can be inserted into the linker libraries list to 
+        # ensure proper resolving of circular references between a subset of the libraries.
+        set(START_LIBRARY_GROUP -Wl,--start-group)
+        set(END_LIBRARY_GROUP -Wl,--end-group)
+    endif(CLR_CMAKE_PLATFORM_LINUX)
 endif(WIN32)
 
 add_library(mscordaccore SHARED ${CLR_DAC_SOURCES})


### PR DESCRIPTION
Hey, refactored your cmake stuff a little so that it can at least build and link on OSX.

Using an lldb checkout to get the public API, and Xcode's private framework can be achieved like so:

LLDB_INCLUDE_DIR=/Users/plasma/Work/lldb/include
LLDB_LIB_DIR=/Applications/Xcode.app/Contents/SharedFrameworks

*Third time is a charm
